### PR TITLE
Compatibility Issue

### DIFF
--- a/style.css
+++ b/style.css
@@ -20,7 +20,16 @@
 .BF-folderSidebar {
   display: flex;
 }
+/*
+.macButtons-2MuSAC.navIsOpen {
+  width: 200% !important;
+  padding-right: calc(100% + 10px);
+}
 
+.BF-folderSidebar .wrapper-3NnKdC {
+  margin-top: 0;
+}
+*/
 .BF-icon {
   margin: 0 0 8px 8px;
   background-color: rgba(248, 247, 255, 0.05);


### PR DESCRIPTION
When used with [Frosted Glass](https://github.com/DiscordStyles/FrostedGlass.git), there is a visible issue in the top corner on macOS.
![Screen Shot 2021-04-03 at 9 38 43 AM](https://user-images.githubusercontent.com/81717531/113481665-6360ed80-9460-11eb-841f-fca3017a0886.png)
I added 2 different css definitions in this pull request. Currently both are commented out, you will need to pick one and delete the other. This is because either will fix the problem, although one would fix it better. Here is what they do, starting with the second one:

The second one will remove the 32px margin at the top of the scroller, removing the gap.
![Screen Shot 2021-04-03 at 9 41 32 AM](https://user-images.githubusercontent.com/81717531/113481721-c8b4de80-9460-11eb-96f3-c475176782e6.png)
While this is a working solution, its not as clean as the other one in my opinion. The first css definition is a bit more complicated. While harder to see here, this doubles the width (width: 200%) of the div surrounding the buttons, and adds a 100% padding on the right so the buttons stay where they need to be.
![Screen Shot 2021-04-03 at 9 45 00 AM](https://user-images.githubusercontent.com/81717531/113481794-44169000-9461-11eb-9a78-115e03b6f574.png)
The problem with this one is that it needs to be removed when all folders are closed. In vanilla js that would be this.
```js
buttons = document.querySelector('.macButtons-2MuSAC')

// When folders are opened
buttons.classList.add('navIsOpen')

// When folders are closed
buttons.classList.remove('navIsOpen')
```
However, this may be achievable in react. As I am not very experienced with react, I'll leave the choice to you. If you want to use the first css definition, you will have to write your own code to handle when the class is added to the div, so it only opens when necessary. If you use the second one you would just have to remove the comments on it, plug and play.